### PR TITLE
Fix README.md headers not showing correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-#ChampionMasteryLookup
+# ChampionMasteryLookup
 This is the source code for [ChampionMasteryLookup](http://championmasterylookup.derpthemeus.com)
 
 
 
-#Setup
+# Setup
 This section is if you want to host your own version of the website. If you just want to use it, check out the [live version](http://championmasterylookup.derpthemeus.com)
 
 The live website is hosted on [OpenShift](https://www.openshift.com/), so if you want to host your own site thats the easiest way to do it.
@@ -11,13 +11,13 @@ It uses the Node.js 0.10 cartridge and requires the RIOT_API_KEY environment var
 
 
 
-#Notes
+# Notes
 The code has very few comments and my be hard to understand. I don't have much experience working with Javascript, so I'm sure there are plenty of amateur mistakes.
 Feel free to make a pull request or open an issue if you want to add or improve anything.
 
 Also, I don't like documenting stuff, so there isn't much info in this README
 
-#License
+# License
 Licensed under the "Do whatever you want as long as you're not a dick license".
 Everything I know about Javascript I learned from the internet and playing around with other peoples' code. I want everyone to have the same opportunity I did, so feel free to modify the code as much as you want and host your own version of the website as long as you're not a dick. Examples of dickish behavior include:
 
@@ -27,4 +27,4 @@ Everything I know about Javascript I learned from the internet and playing aroun
 
 
 #
- ChampionMasteryLookup isn't endorsed by Riot Games and doesn't reflect the views or opinions of Riot Games or anyone officially involved in producing or managing League of Legends. League of Legends and Riot Games are trademarks or registered trademarks of Riot Games, Inc. League of Legends © Riot Games, Inc.
+ChampionMasteryLookup isn't endorsed by Riot Games and doesn't reflect the views or opinions of Riot Games or anyone officially involved in producing or managing League of Legends. League of Legends and Riot Games are trademarks or registered trademarks of Riot Games, Inc. League of Legends © Riot Games, Inc.


### PR DESCRIPTION
README.md, specifically its headings, did not show up correctly for me and it's been bugging me for some time, so here's my fix for that. It seems that you need to put a space between `#` and the title following after it.